### PR TITLE
Improve cache hashing and watcher responsiveness

### DIFF
--- a/src/cache.rs
+++ b/src/cache.rs
@@ -1,69 +1,141 @@
 use anyhow::Result;
 use sha2::{Digest, Sha256};
-use std::fs;
-use std::path::Path;
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use tokio::task;
 
-#[derive(Debug)]
+const CACHE_VERSION: &str = "taskrush-cache-v1";
+
+#[derive(Debug, Clone)]
 pub struct TaskCache {
-    cache_dir: String,
+    cache_dir: PathBuf,
 }
 
 impl TaskCache {
     pub fn new() -> Self {
         Self {
-            cache_dir: ".rush-cache".to_string(),
+            cache_dir: PathBuf::from(".rush-cache"),
         }
     }
 
-    pub fn ensure_cache_dir(&self) -> Result<()> {
-        fs::create_dir_all(&self.cache_dir)?;
-        Ok(())
+    pub fn cache_dir(&self) -> &Path {
+        &self.cache_dir
     }
 
-    pub fn compute_task_hash(&self, task_name: &str, cache_files: &[String]) -> Result<String> {
-        let mut hasher = Sha256::new();
+    pub async fn compute_task_hash(
+        &self,
+        task_name: &str,
+        command: &str,
+        env: &HashMap<String, String>,
+        dependencies: &[String],
+        cache_files: &[String],
+    ) -> Result<String> {
+        let task_name = task_name.to_string();
+        let command = command.to_string();
+        let mut env_pairs: Vec<_> = env.iter().map(|(k, v)| (k.clone(), v.clone())).collect();
+        env_pairs.sort_by(|a, b| a.0.cmp(&b.0));
 
-        // Hash the task name
-        hasher.update(task_name.as_bytes());
+        let mut dependency_list = dependencies.to_vec();
+        dependency_list.sort();
 
-        // Hash each cache file's content
-        for file_path in cache_files {
-            if Path::new(file_path).exists() {
-                let content = fs::read(file_path)?;
-                hasher.update(&content);
-            } else {
-                // Hash the fact that the file doesn't exist
-                hasher.update(b"<file-not-found>");
+        let mut cache_inputs: Vec<_> = cache_files.iter().cloned().collect();
+        cache_inputs.sort();
+
+        task::spawn_blocking(move || -> Result<String> {
+            let mut hasher = Sha256::new();
+
+            hasher.update(CACHE_VERSION.as_bytes());
+            hasher.update(task_name.as_bytes());
+            hasher.update(command.as_bytes());
+
+            for (key, value) in env_pairs {
+                hasher.update(key.as_bytes());
+                hasher.update(b"=");
+                hasher.update(value.as_bytes());
             }
-        }
 
-        let result = hasher.finalize();
-        Ok(format!("{result:x}"))
-    }
+            for dep in dependency_list {
+                hasher.update(dep.as_bytes());
+            }
 
-    pub fn is_cached(&self, task_name: &str, hash: &str) -> bool {
-        let cache_file = format!("{}/{}.{}", self.cache_dir, task_name, hash);
-        Path::new(&cache_file).exists()
-    }
-
-    pub fn mark_cached(&self, task_name: &str, hash: &str) -> Result<()> {
-        self.ensure_cache_dir()?;
-
-        // Remove old cache files for this task
-        if let Ok(entries) = fs::read_dir(&self.cache_dir) {
-            for entry in entries.flatten() {
-                let file_name = entry.file_name();
-                let file_name_str = file_name.to_string_lossy();
-                if file_name_str.starts_with(&format!("{task_name}.")) {
-                    let _ = fs::remove_file(entry.path());
+            for file_path in cache_inputs {
+                let path = Path::new(&file_path);
+                if path.exists() {
+                    let content = std::fs::read(path)?;
+                    hasher.update(&content);
+                } else {
+                    hasher.update(b"<file-not-found>");
+                    hasher.update(file_path.as_bytes());
                 }
             }
-        }
 
-        // Create new cache marker
-        let cache_file = format!("{}/{}.{}", self.cache_dir, task_name, hash);
-        fs::write(cache_file, "")?;
+            let result = hasher.finalize();
+            Ok(format!("{result:x}"))
+        })
+        .await?
+    }
 
-        Ok(())
+    pub async fn is_cached(&self, task_name: &str, hash: &str) -> Result<bool> {
+        let cache_dir = self.cache_dir.clone();
+        let task_name = task_name.to_string();
+        let hash = hash.to_string();
+
+        task::spawn_blocking(move || -> Result<bool> {
+            let cache_file = cache_dir.join(format!("{}.{}", task_name, hash));
+            Ok(cache_file.exists())
+        })
+        .await?
+    }
+
+    pub async fn mark_cached(&self, task_name: &str, hash: &str) -> Result<()> {
+        let cache_dir = self.cache_dir.clone();
+        let task_name = task_name.to_string();
+        let hash = hash.to_string();
+
+        task::spawn_blocking(move || -> Result<()> {
+            std::fs::create_dir_all(&cache_dir)?;
+
+            if let Ok(entries) = std::fs::read_dir(&cache_dir) {
+                for entry in entries.flatten() {
+                    let file_name = entry.file_name();
+                    let file_name_str = file_name.to_string_lossy();
+                    if file_name_str.starts_with(&format!("{task_name}.")) {
+                        let _ = std::fs::remove_file(entry.path());
+                    }
+                }
+            }
+
+            let cache_file = cache_dir.join(format!("{}.{}", task_name, hash));
+            std::fs::write(&cache_file, b"")?;
+
+            Ok(())
+        })
+        .await?
+    }
+
+    pub async fn invalidate_task(&self, task_name: &str) -> Result<()> {
+        let cache_dir = self.cache_dir.clone();
+        let task_name = task_name.to_string();
+
+        task::spawn_blocking(move || -> Result<()> {
+            if !cache_dir.exists() {
+                return Ok(());
+            }
+
+            if let Ok(entries) = std::fs::read_dir(&cache_dir) {
+                for entry in entries.flatten() {
+                    let file_name = entry.file_name();
+                    if file_name
+                        .to_string_lossy()
+                        .starts_with(&format!("{task_name}."))
+                    {
+                        let _ = std::fs::remove_file(entry.path());
+                    }
+                }
+            }
+
+            Ok(())
+        })
+        .await?
     }
 }

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -1,11 +1,13 @@
 use anyhow::{Context, Result};
 use indicatif::{ProgressBar, ProgressStyle};
 use notify::{Event, RecommendedWatcher, RecursiveMode, Watcher};
-use std::path::Path;
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
 use std::process::Stdio;
-use std::sync::mpsc;
 use std::time::{Duration, Instant};
 use tokio::process::Command;
+use tokio::sync::mpsc;
+use tokio::time::sleep;
 
 use crate::cache::TaskCache;
 use crate::graph::{Task, TaskGraph};
@@ -14,14 +16,17 @@ pub struct TaskExecutor {
     graph: TaskGraph,
     cache: TaskCache,
     verbose: bool,
+    workspace_root: PathBuf,
 }
 
 impl TaskExecutor {
     pub fn new(graph: TaskGraph, verbose: bool) -> Self {
+        let workspace_root = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
         Self {
             graph,
             cache: TaskCache::new(),
             verbose,
+            workspace_root,
         }
     }
 
@@ -201,15 +206,23 @@ impl TaskExecutor {
     }
 
     async fn run_single_task(&self, task: &Task) -> Result<()> {
-        // Check cache if cache files are specified
+        let mut cached_hash: Option<String> = None;
         if !task.cache_files.is_empty() {
             let hash = self
                 .cache
-                .compute_task_hash(&task.name, &task.cache_files)?;
-            if self.cache.is_cached(&task.name, &hash) {
+                .compute_task_hash(
+                    &task.name,
+                    &task.cmd,
+                    &task.env,
+                    &task.deps,
+                    &task.cache_files,
+                )
+                .await?;
+            if self.cache.is_cached(&task.name, &hash).await? {
                 println!("⚡ Task '{}' skipped (cached)", task.name);
                 return Ok(());
             }
+            cached_hash = Some(hash);
         }
 
         println!("🏃 Running task: {}", task.name);
@@ -239,12 +252,8 @@ impl TaskExecutor {
                 println!("{}", String::from_utf8_lossy(&output.stdout));
             }
 
-            // Cache the result if cache files are specified
-            if !task.cache_files.is_empty() {
-                let hash = self
-                    .cache
-                    .compute_task_hash(&task.name, &task.cache_files)?;
-                self.cache.mark_cached(&task.name, &hash)?;
+            if let Some(hash) = cached_hash {
+                self.cache.mark_cached(&task.name, &hash).await?;
             }
         } else {
             println!("❌ Task '{}' failed", task.name);
@@ -272,8 +281,7 @@ impl TaskExecutor {
 
         println!("👀 Watching for file changes... (Press Ctrl+C to stop)");
 
-        // Set up file watcher
-        let (tx, rx) = mpsc::channel();
+        let (tx, mut rx) = mpsc::unbounded_channel();
         let mut watcher: RecommendedWatcher = Watcher::new(
             move |res: notify::Result<Event>| {
                 if let Ok(event) = res {
@@ -286,39 +294,67 @@ impl TaskExecutor {
         // Watch current directory
         watcher.watch(Path::new("."), RecursiveMode::Recursive)?;
 
-        // Watch loop
-        loop {
-            match rx.recv_timeout(Duration::from_millis(100)) {
-                Ok(_event) => {
-                    // Debounce: wait a bit for more changes
-                    std::thread::sleep(Duration::from_millis(200));
+        let cache_root = self.normalize_to_workspace(self.cache.cache_dir());
 
-                    // Drain any additional events
-                    while rx.try_recv().is_ok() {}
+        while let Some(event) = rx.recv().await {
+            if self.should_ignore_event(&event, &cache_root) {
+                continue;
+            }
 
-                    println!("\n🔄 File change detected, re-running task: {task_name}");
+            let mut aggregated_events = vec![event];
+            let debounce = sleep(Duration::from_millis(200));
+            tokio::pin!(debounce);
 
-                    // Clear cache to force rebuild
-                    let _ = std::fs::remove_dir_all(".rush-cache");
-
-                    if parallel {
-                        if let Err(e) = self.execute_task_parallel(task_name).await {
-                            eprintln!("❌ Task failed: {e}");
+            loop {
+                tokio::select! {
+                    _ = &mut debounce => break,
+                    maybe_event = rx.recv() => {
+                        match maybe_event {
+                            Some(next_event) => {
+                                if !self.should_ignore_event(&next_event, &cache_root) {
+                                    aggregated_events.push(next_event);
+                                }
+                            }
+                            None => return Ok(()),
                         }
-                    } else if let Err(e) = self.execute_task(task_name).await {
-                        eprintln!("❌ Task failed: {e}");
                     }
-
-                    println!("👀 Watching for more changes...");
-                }
-                Err(mpsc::RecvTimeoutError::Timeout) => {
-                    // No events, continue watching
-                    tokio::task::yield_now().await;
-                }
-                Err(mpsc::RecvTimeoutError::Disconnected) => {
-                    break;
                 }
             }
+
+            let changed_paths: Vec<PathBuf> = aggregated_events
+                .into_iter()
+                .flat_map(|event| event.paths.into_iter())
+                .collect();
+
+            if changed_paths.is_empty() {
+                continue;
+            }
+
+            let mut affected_tasks: Vec<String> = self
+                .affected_tasks_for_paths(&changed_paths, &cache_root)
+                .into_iter()
+                .collect();
+            affected_tasks.sort();
+
+            for task in &affected_tasks {
+                self.cache.invalidate_task(task).await?;
+            }
+
+            println!("\n🔄 File change detected, re-running task: {task_name}");
+
+            if parallel {
+                if let Err(e) = self.execute_task_parallel(task_name).await {
+                    eprintln!("❌ Task failed: {e}");
+                }
+            } else if let Err(e) = self.execute_task(task_name).await {
+                eprintln!("❌ Task failed: {e}");
+            }
+
+            if !affected_tasks.is_empty() {
+                println!("   Cache invalidated for: {}", affected_tasks.join(", "));
+            }
+
+            println!("👀 Watching for more changes...");
         }
 
         Ok(())
@@ -331,15 +367,23 @@ impl TaskExecutor {
     ) -> Result<()> {
         let start_time = Instant::now();
 
-        // Check cache if cache files are specified
+        let mut cached_hash: Option<String> = None;
         if !task.cache_files.is_empty() {
             let hash = self
                 .cache
-                .compute_task_hash(&task.name, &task.cache_files)?;
-            if self.cache.is_cached(&task.name, &hash) {
+                .compute_task_hash(
+                    &task.name,
+                    &task.cmd,
+                    &task.env,
+                    &task.deps,
+                    &task.cache_files,
+                )
+                .await?;
+            if self.cache.is_cached(&task.name, &hash).await? {
                 progress.set_message(format!("⚡ {} (cached)", task.name));
                 return Ok(());
             }
+            cached_hash = Some(hash);
         }
 
         progress.set_message(format!("🏃 Running {}", task.name));
@@ -367,12 +411,8 @@ impl TaskExecutor {
         if output.status.success() {
             progress.set_message(format!("✅ {} ({:.1}s)", task.name, elapsed.as_secs_f32()));
 
-            // Cache the result if cache files are specified
-            if !task.cache_files.is_empty() {
-                let hash = self
-                    .cache
-                    .compute_task_hash(&task.name, &task.cache_files)?;
-                self.cache.mark_cached(&task.name, &hash)?;
+            if let Some(hash) = cached_hash {
+                self.cache.mark_cached(&task.name, &hash).await?;
             }
         } else {
             progress.set_message(format!("❌ {} failed", task.name));
@@ -400,13 +440,22 @@ impl TaskExecutor {
     ) -> Result<()> {
         let start_time = Instant::now();
 
-        // Check cache if cache files are specified
+        let mut cached_hash: Option<String> = None;
         if !task.cache_files.is_empty() {
-            let hash = cache.compute_task_hash(&task.name, &task.cache_files)?;
-            if cache.is_cached(&task.name, &hash) {
+            let hash = cache
+                .compute_task_hash(
+                    &task.name,
+                    &task.cmd,
+                    &task.env,
+                    &task.deps,
+                    &task.cache_files,
+                )
+                .await?;
+            if cache.is_cached(&task.name, &hash).await? {
                 progress.set_message(format!("⚡ {} (cached)", task.name));
                 return Ok(());
             }
+            cached_hash = Some(hash);
         }
 
         progress.set_message(format!("🏃 Running {}", task.name));
@@ -434,10 +483,8 @@ impl TaskExecutor {
         if output.status.success() {
             progress.set_message(format!("✅ {} ({:.1}s)", task.name, elapsed.as_secs_f32()));
 
-            // Cache the result if cache files are specified
-            if !task.cache_files.is_empty() {
-                let hash = cache.compute_task_hash(&task.name, &task.cache_files)?;
-                cache.mark_cached(&task.name, &hash)?;
+            if let Some(hash) = cached_hash {
+                cache.mark_cached(&task.name, &hash).await?;
             }
         } else {
             progress.set_message(format!("❌ {} failed", task.name));
@@ -456,5 +503,51 @@ impl TaskExecutor {
         }
 
         Ok(())
+    }
+
+    fn normalize_to_workspace(&self, path: &Path) -> PathBuf {
+        if path.is_absolute() {
+            path.to_path_buf()
+        } else {
+            self.workspace_root.join(path)
+        }
+    }
+
+    fn should_ignore_event(&self, event: &Event, cache_root: &Path) -> bool {
+        if event.paths.is_empty() {
+            return false;
+        }
+
+        event
+            .paths
+            .iter()
+            .all(|path| self.normalize_to_workspace(path).starts_with(cache_root))
+    }
+
+    fn affected_tasks_for_paths(&self, paths: &[PathBuf], cache_root: &Path) -> HashSet<String> {
+        let mut affected = HashSet::new();
+
+        for path in paths {
+            let absolute_path = self.normalize_to_workspace(path);
+
+            if absolute_path.starts_with(cache_root) {
+                continue;
+            }
+
+            for (name, task) in &self.graph.tasks {
+                if task.cache_files.is_empty() {
+                    continue;
+                }
+
+                if task.cache_files.iter().any(|cache_file| {
+                    let cache_path = Path::new(cache_file);
+                    self.normalize_to_workspace(cache_path) == absolute_path
+                }) {
+                    affected.insert(name.clone());
+                }
+            }
+        }
+
+        affected
     }
 }

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -13,6 +13,7 @@ pub struct Task {
     pub cmd: String,
     pub env: HashMap<String, String>,
     pub cache_files: Vec<String>,
+    pub deps: Vec<String>,
 }
 
 impl TaskGraph {
@@ -29,7 +30,16 @@ impl TaskGraph {
     }
 
     pub fn add_dependency(&mut self, task: String, dependency: String) {
-        self.dependencies.entry(task).or_default().push(dependency);
+        self.dependencies
+            .entry(task.clone())
+            .or_default()
+            .push(dependency.clone());
+
+        if let Some(task_entry) = self.tasks.get_mut(&task) {
+            if !task_entry.deps.contains(&dependency) {
+                task_entry.deps.push(dependency);
+            }
+        }
     }
 
     pub fn topological_sort(&self, start_task: &str) -> Result<Vec<String>> {
@@ -110,6 +120,7 @@ impl From<&crate::config::RushConfig> for TaskGraph {
                 cmd: task_config.cmd.clone(),
                 env: task_config.env.clone(),
                 cache_files: task_config.cache.clone(),
+                deps: task_config.deps.clone(),
             };
 
             graph.add_task(name.clone(), task);


### PR DESCRIPTION
- include command, environment, dependencies, and stable cache version in task hashes while running file IO in spawn_blocking
- add targeted cache invalidation helpers and reuse them from async task execution paths
- replace the blocking watch loop with tokio channels and debounced sleep so rebuilds only invalidate affected tasks